### PR TITLE
fix(plugin-grainline/plugin-cutonfold): Adapt to store methods

### DIFF
--- a/plugins/plugin-cutonfold/src/index.mjs
+++ b/plugins/plugin-cutonfold/src/index.mjs
@@ -19,14 +19,17 @@ export const plugin = {
   },
   macros: {
     cutonfold: function (so) {
-      const { points, complete } = this.shorthand()
+      const { points, complete, setCutOnFold, setGrain } = this.shorthand()
       if (so === false) {
         delete this.points.cutonfoldFrom
         delete this.points.cutonfoldTo
         delete this.points.cutonfoldVia1
         delete this.points.cutonfoldVia2
         delete this.paths.cutonfold
-        this.setCutOnFold(false) // Restore default
+        // setCutOnFold relies on plugin-cutlist
+        if (typeof setCutOnFold === 'function') {
+          setCutOnFold(false) // Restore default
+        }
         return true
       }
       so = {
@@ -35,8 +38,10 @@ export const plugin = {
         prefix: '',
         ...so,
       }
-      this.setCutOnFold(so.from, so.to)
-      if (so.grainline) this.setGrain(so.from.angle(so.to))
+      if (typeof setCutOnFold === 'function') {
+        setCutOnFold(so.from, so.to)
+        if (so.grainline) setGrain(so.from.angle(so.to))
+      }
       if (complete) {
         points['cutonfoldFrom' + so.prefix] = so.from.shiftFractionTowards(so.to, so.margin / 100)
         points['cutonfoldTo' + so.prefix] = so.to.shiftFractionTowards(so.from, so.margin / 100)

--- a/plugins/plugin-grainline/src/index.mjs
+++ b/plugins/plugin-grainline/src/index.mjs
@@ -31,8 +31,11 @@ export const plugin = {
         ...dflts,
         ...so,
       }
-      const { points, complete } = this.shorthand()
-      this.setGrain(so.from.angle(so.to))
+      const { points, complete, setGrain } = this.shorthand()
+      // setGrain relies on plugin-cutlist
+      if (typeof setGrain === 'function') {
+        setGrain(so.from.angle(so.to))
+      }
       if (complete) {
         points.grainlineFrom = so.from.shiftFractionTowards(so.to, 0.05)
         points.grainlineTo = so.to.shiftFractionTowards(so.from, 0.05)

--- a/plugins/plugin-grainline/tests/plugin.test.mjs
+++ b/plugins/plugin-grainline/tests/plugin.test.mjs
@@ -1,12 +1,13 @@
 import chai from 'chai'
-import { round, Pattern } from '@freesewing/core'
+import { round, Design } from '@freesewing/core'
 import { plugin } from './dist/index.mjs'
 
 const expect = chai.expect
 
 describe('Grainline Plugin Tests', () => {
   it('Should run the default grainline macro', () => {
-    const pattern = new Pattern().use(plugin)
+    const Pattern = new Design({ plugins: [ plugin ]})
+    const pattern = new Pattern()
     pattern.parts.test = new pattern.Part()
     pattern.parts.test.points.from = new pattern.Point(10, 20)
     pattern.parts.test.points.to = new pattern.Point(10, 230)


### PR DESCRIPTION
This adapts an early v3 idea to set grainline and cutOnFold data to use the new store methods as added by plugin-cutlist.